### PR TITLE
Make pinned main images appear in carousel

### DIFF
--- a/src/app/Http/Controllers/PostagemController.php
+++ b/src/app/Http/Controllers/PostagemController.php
@@ -215,6 +215,7 @@ class PostagemController extends Controller
     {
         $postagem =  Postagem::findOrFail($id);
         $tipo_postagem = TipoPostagem::findOrFail($postagem->tipo_postagem_id);
+        dd($postagem->imagens->isEmpty());
         return view('postagem.show', ['postagem' => $postagem, 'tipo_postagem' => $tipo_postagem]);
     }
 
@@ -222,8 +223,9 @@ class PostagemController extends Controller
     {
         $pinnedpost = PinnedPosts::find($postagem->id);
         $imagens = $postagem->imagens;
+        $sucess = true;
 
-        if ($imagens->items->isNotEmpty()) {
+        if ($imagens->isNotEmpty()) {
             $imagem = $imagens->first();
             $imagempath = $imagem->imagem;
 
@@ -245,10 +247,11 @@ class PostagemController extends Controller
         } else {
             $status = 'error';
             $message = "nenhuma imagem encontrada para essa postagem.";
+            $sucess = false;
         }
 
         return response()->json([
-            'success' => true,
+            'success' => $sucess,
             'status' => $status,
             'message' => $message,
             'imagens' => $imagens,

--- a/src/app/Models/PinnedPosts.php
+++ b/src/app/Models/PinnedPosts.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PinnedPosts extends Model
+{
+
+  protected $table = 'pinned_posts';
+
+  public $incrementing = false;
+  protected $primaryKey = 'postagem_id';
+
+
+  protected $fillable = [
+    'postagem_id',
+  ];
+
+  public function getPost()
+  {
+    return $this->belongsTo(Postagem::class, 'postagem_id', 'id');
+  }
+}

--- a/src/app/Models/Postagem.php
+++ b/src/app/Models/Postagem.php
@@ -22,4 +22,28 @@ class Postagem extends Model {
     public function arquivos(){
         return $this->hasMany(ArquivoPostagem::class);
     }
+
+    public function isPinned(){
+      return PinnedPosts::where('postagem_id', $this->id)->exists();
+    }
+
+
+    public static function checkMainImageSize($imagem)
+    {
+        $filepath = public_path('storage/' . $imagem);
+
+        if (!file_exists($filepath)) {
+            return false;
+        }
+
+        $dimensions = getimagesize($filepath);
+        if ($dimensions === false) {
+            return false;
+        }
+
+        $largura = $dimensions[0];
+        $altura = $dimensions[1];
+
+        return $largura === 2700 && $altura === 660;
+    }
 }

--- a/src/database/migrations/2025_07_10_140935_create_pinned_posts_table.php
+++ b/src/database/migrations/2025_07_10_140935_create_pinned_posts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pinned_posts', function (Blueprint $table) {
+            $table->foreignId('postagem_id')->constrained(
+                table: 'postagem'
+            )->onDelete("cascade");
+            $table->primary('postagem_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pinned_posts');
+    }
+};

--- a/src/resources/views/postagem/display.blade.php
+++ b/src/resources/views/postagem/display.blade.php
@@ -5,13 +5,15 @@
 @php
 $imagensPostagens = [];
 foreach ($postagens as $postagem) {
-$firstImage = $postagem->imagens->first();
-if ($firstImage && Storage::disk('public')->exists($firstImage->imagem) && $postagem->menu_inicial) {
-$imagensPostagens[] = [
-'postagem' => $postagem,
-'imagem' => $firstImage,
-];
-}
+    if ($postagem->isPinned()) {
+        $firstImage = $postagem->imagens->first();
+        if ($firstImage && Storage::disk('public')->exists($firstImage->imagem)) {
+            $imagensPostagens[] = [
+                'postagem' => $postagem,
+                'imagem' => $firstImage,
+            ];
+        }
+    }
 }
 @endphp
 

--- a/src/resources/views/postagem/index.blade.php
+++ b/src/resources/views/postagem/index.blade.php
@@ -34,6 +34,7 @@
                                     <th>Título</th>
                                     <th>Criação</th>
                                     <th>Ação</th>
+                                    <th>Fixar</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -52,6 +53,14 @@
                                             <a href="{{ route('postagem.edit', $postagem->id) }}" class="btn btn-primary btn-sm"><i class="fas fa-pencil-alt"></i></a>
                                             <button type="submit" class="btn btn-danger btn-sm" title='Delete' onclick="return confirm('Deseja realmente excluir esse registro?')"><i class="fas fa-trash"></i></button>
                                         </form>
+                                    </td>
+                                    <td>
+                                        <div class="form-check d-flex">
+                                            <input class="form-check-input pin-post-checkbox" type="checkbox"
+                                                   id="pinPost{{ $postagem->id }}"
+                                                   data-post-id="{{ $postagem->id }}"
+                                                   {{ $postagem->isPinned() ? 'checked' : '' }}>
+                                        </div>
                                     </td>
                                 </tr>
                                 @endforeach
@@ -74,6 +83,41 @@
                 // Excluindo a última coluna que é a de ação do filtro
                 var rowData = $(this).find("td:not(:last-child)").text().toLowerCase();
                 $(this).toggle(rowData.indexOf(searchText) > -1);
+            });
+        });
+    });
+
+    const checkboxes = document.querySelectorAll('.pin-post-checkbox');
+
+    checkboxes.forEach(checkbox => {
+        checkbox.addEventListener('change', function () {
+            const postId = this.dataset.postId;
+            const isChecked = this.checked;
+            const url = `{{ url('/postagens') }}/${postId}/toggle-pin`;
+
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': '{{ csrf_token() }}' 
+                },
+                body: JSON.stringify({
+                    _token: '{{ csrf_token() }}',
+                })
+            })
+            .then(response => response.json())
+            .then(data => {
+                console.log(data);
+                if (data.success) {
+                    console.log(data.message);
+                } else {
+                    console.error('Erro ao alternar o status de fixação:', data.message);
+                    this.checked = !isChecked;
+                }
+            })
+            .catch(error => {
+                console.error('Erro na requisição:', error);
+                this.checked = !isChecked;
             });
         });
     });

--- a/src/resources/views/postagem/index.blade.php
+++ b/src/resources/views/postagem/index.blade.php
@@ -112,7 +112,8 @@
                     console.log(data.message);
                 } else {
                     console.error('Erro ao alternar o status de fixação:', data.message);
-                    this.checked = !isChecked;
+                    this.checked = false;
+                    alert(data.message);
                 }
             })
             .catch(error => {

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -109,6 +109,7 @@ Route::middleware('auth', 'role:coordenador')->group(function () {
 
     Route::delete('/postagem/delete_imagem/{id}', [PostagemController::class, 'deleteImagem'])->name('postagem.delete_imagem');
     Route::delete('/postagem/delete_arquivo/{id}', [PostagemController::class, 'deleteArquivo'])->name('postagem.delete_arquivo');
+    Route::post('/postagens/{postagem}/toggle-pin', [PostagemController::class, 'togglePin'])->name('postagem.toggle-pin');
 
     //Banca
     Route::resource('banca', BancaController::class)->parameter('banca', 'id')->except(['show']);


### PR DESCRIPTION
## Classification

- [x] New feature
- [ ] Fixing bugs
- [ ] Improving the project
- [ ] Other (which one?)

## Description

This pull request introduces a new feature that allows users to pin posts based on the main image of the post. The pinning functionality has been added to the backend and frontend, ensuring that posts with images can be easily pinned or unpinned by the user. If a post does not contain an image, the user will receive an error message indicating that the post cannot be pinned without an image.

## What has been done

- Backend logic added to handle pinning and unpinning posts.
- Image validation for posts to ensure that only posts with an image can be pinned.
- Error handling implemented for cases when no images are available for a post.

## Overview


[Screencast from 2025-07-14 21-25-24.webm](https://github.com/user-attachments/assets/9c325f7f-434f-4f0d-a04a-201fb24650b2)
