### PR TITLE
Separate logic for post images and cover image

### DIFF
--- a/src/app/Http/Controllers/PostagemController.php
+++ b/src/app/Http/Controllers/PostagemController.php
@@ -7,6 +7,7 @@ use App\Models\Aluno;
 use App\Models\ArquivoPostagem;
 use App\Models\Banca;
 use App\Models\ImagemPostagem;
+use App\Models\CapaPostagem;
 use App\Models\Postagem;
 use App\Models\Professor;
 use App\Models\TipoPostagem;
@@ -73,32 +74,40 @@ class PostagemController extends Controller
             'titulo' => $request->titulo,
             'texto' => $request->texto,
             'tipo_postagem_id' => $request->tipo_postagem_id,
-            'menu_inicial' => $request->has('menu_inicial')
+            'menu_inicial' => false,
         ]);
 
-        if ($request->has('menu_inicial')) {
-            if ($request->hasFile("imagens")) {
-                $imagens = $request->file("imagens");
-                if(!Postagem::checkMainImageSize($imagens[0])){
-                    return redirect()->back()->withInput()->with('error', 'A primeira imagem para exibição no menu inicial deve ter as dimensões de 2700 x 660.');
-                }
-            } else {
-                return redirect()->back()->withInput()->with('error', 'Foi solicitado que aparecesse na tela inicial com destaque, mas nenhuma imagem foi cadastrada.');
+        if ($request->hasFile("main_image")) {
+            $mainImage = $request->file("main_image");
+
+            if (!Postagem::checkMainImageSize($mainImage)) {
+                return redirect()->back()->withInput()->with('error', 'A imagem de capa deve ter as dimensões de 2700 x 660.');
             }
+
+            $postagem->menu_inicial = true;
         }
 
         $postagem->save();
 
+        if ($request->hasFile("main_image")) {
+            $mainImage = $request->file("main_image");
+
+            if ($mainImage->isValid() && str_starts_with($mainImage->getMimeType(), 'image/')) {
+                $capaPostagem = new CapaPostagem();
+                $capaPostagem->postagem_id = $postagem->id;
+                $capaPostagem->imagem = $mainImage->store('CapaPostagem/' . $postagem->id, 'public');
+                $capaPostagem->save();
+            }
+        }
+
         if ($request->hasFile("imagens")) {
             $imagens = $request->file("imagens");
-
             foreach ($imagens as $imagem) {
                 if ($imagem->isValid() && str_starts_with($imagem->getMimeType(), 'image/')) {
                     $imagemPostagem = new ImagemPostagem();
                     $imagemPostagem->postagem_id = $postagem->id;
                     $imagemPostagem->imagem = $imagem->store('ImagemPostagem/' . $postagem->id, 'public');
                     $imagemPostagem->save();
-                } else {
                 }
             }
         }
@@ -140,16 +149,31 @@ class PostagemController extends Controller
     {
         $postagem = Postagem::findOrFail($id);
 
+        if ($request->hasFile("main_image")) {
+            $mainImage = $request->file("main_image");
+
+            if (!Postagem::checkMainImageSize($mainImage)) {
+                return redirect()->back()->withInput()->with('error', 'A imagem de capa deve ter as dimensões de 2700 x 660.');
+            }
+
+            if ($mainImage->isValid() && str_starts_with($mainImage->getMimeType(), 'image/')) {
+                $capaPostagem = new CapaPostagem();
+                $capaPostagem->postagem_id = $postagem->id;
+                $capaPostagem->imagem = $mainImage->store('CapaPostagem/' . $postagem->id, 'public');
+                $capaPostagem->save();
+            }
+            $postagem->menu_inicial = true;
+        }
+
         $postagem->update([
             'titulo' => $request->titulo,
             'texto' => $request->texto,
             'tipo_postagem_id' => $request->tipo_postagem_id,
-            'menu_inicial' => $request->has('menu_inicial')
+            'menu_inicial' => $postagem->menu_inicial ?? false
         ]);
 
         if ($request->hasFile("imagens")) {
             $imagens = $request->file("imagens");
-
             foreach ($imagens as $imagem) {
                 if ($imagem->isValid() && str_starts_with($imagem->getMimeType(), 'image/')) {
                     $imagemPostagem = new ImagemPostagem();
@@ -229,36 +253,34 @@ class PostagemController extends Controller
     {
         $postagem = Postagem::findOrFail($id);
         $tipo_postagem = TipoPostagem::findOrFail($postagem->tipo_postagem_id);
-        dd($postagem->imagens->isEmpty());
         return view('postagem.show', ['postagem' => $postagem, 'tipo_postagem' => $tipo_postagem]);
     }
 
     public function togglePin(postagem $postagem)
     {
+        $capa = $postagem->capa;
+
+        if (!$capa) {
+            return response()->json([
+                'success' => false,
+                'status' => 'error',
+                'message' => "Nenhuma imagem encontrada para essa postagem.",
+            ]);
+        }
+
+        $imagem = $capa->imagem;
+        $imagePath = public_path('storage/' . $imagem);
+
+        if (!postagem::checkMainImageSize($imagePath)) {
+            return response()->json([
+                'success' => false,
+                'status' => 'error',
+                'message' => "A imagem principal não possui as dimensões necessárias.",
+
+            ]);
+        }
+
         $pinnedpost = PinnedPosts::find($postagem->id);
-        $imagens = $postagem->imagens;
-
-        if ($imagens->isEmpty()) {
-            return response()->json([
-                'success' => false,
-                'status' => 'error',
-                'message' => "nenhuma imagem encontrada para essa postagem.",
-                'imagens' => $imagens,
-            ]);
-        }
-
-        $imagem = $imagens->first();
-        $imagempath = $imagem->imagem;
-
-        if (!postagem::checkMainImageSize($imagempath)) {
-            return response()->json([
-                'success' => false,
-                'status' => 'error',
-                'message' => "a imagem principal não possui as dimensões necessárias.",
-                'imagens' => $imagens,
-            ]);
-        }
-
         if ($pinnedpost) {
             $pinnedpost->delete();
             $status = 'unpinned';
@@ -273,7 +295,6 @@ class PostagemController extends Controller
             'success' => true,
             'status' => $status,
             'message' => $message,
-            'imagens' => $imagens,
         ]);
     }
 }

--- a/src/app/Http/Controllers/PostagemController.php
+++ b/src/app/Http/Controllers/PostagemController.php
@@ -51,8 +51,8 @@ class PostagemController extends Controller
                 $postagem = [
                     'titulo' => 'Convite TCC',
                     'texto' =>
-                        'Aluno: ' . $aluno->nome . "\n" .
-                        'Título: ' . old('titulo') . "\n" .
+                    'Aluno: ' . $aluno->nome . "\n" .
+                        'Título: ' . ('titulo') . "\n" .
                         'Orientador: ' . $professor->servidor->nome . "\n" .
                         'Data: ' . date('d/m/Y', strtotime($banca->data)) . "\n" .
                         'Local: ' . $banca->local
@@ -157,6 +157,11 @@ class PostagemController extends Controller
             }
 
             if ($mainImage->isValid() && str_starts_with($mainImage->getMimeType(), 'image/')) {
+                //Apagar capaPostagem antiga
+                $oldCapaPostagem = $postagem->capa;
+                Storage::disk('public')->delete($oldCapaPostagem->imagem);
+                $oldCapaPostagem->delete();
+
                 $capaPostagem = new CapaPostagem();
                 $capaPostagem->postagem_id = $postagem->id;
                 $capaPostagem->imagem = $mainImage->store('CapaPostagem/' . $postagem->id, 'public');
@@ -208,12 +213,13 @@ class PostagemController extends Controller
     {
         $postagem = Postagem::findOrFail($id);
 
-         foreach ($postagem->imagens as $imagem) {
-             Storage::disk('public')->delete($imagem->imagem);
-         }
-         foreach ($postagem->arquivos as $arquivo) {
-             Storage::disk('public')->delete($arquivo->path);
-         }
+        foreach ($postagem->imagens as $imagem) {
+            Storage::disk('public')->delete($imagem->imagem);
+        }
+        foreach ($postagem->arquivos as $arquivo) {
+            Storage::disk('public')->delete($arquivo->path);
+        }
+        Storage::disk('public')->delete($postagem->capa->imagem);
 
         $postagem->delete();
         return back()->with('success', 'Postagem Excluída com Sucesso');

--- a/src/app/Models/CapaPostagem.php
+++ b/src/app/Models/CapaPostagem.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CapaPostagem extends Model
+{
+    use HasFactory;
+
+    protected $table = 'capa_postagem';
+
+    protected $fillable = [
+        'imagem',
+        'postagem_id',
+    ];
+    
+    public function postagem(){
+        return $this->belongsTo(Postagem::class);
+    }
+}

--- a/src/app/Models/Postagem.php
+++ b/src/app/Models/Postagem.php
@@ -19,6 +19,10 @@ class Postagem extends Model {
         return $this->hasMany(ImagemPostagem::class);
     }
 
+    public function capa(){
+        return $this->hasOne(CapaPostagem::class);
+    }
+
     public function arquivos(){
         return $this->hasMany(ArquivoPostagem::class);
     }
@@ -30,13 +34,7 @@ class Postagem extends Model {
 
     public static function checkMainImageSize($imagem)
     {
-        $filepath = public_path('storage/' . $imagem);
-
-        if (!file_exists($filepath)) {
-            return false;
-        }
-
-        $dimensions = getimagesize($filepath);
+        $dimensions = getimagesize($imagem);
         if ($dimensions === false) {
             return false;
         }

--- a/src/database/migrations/2025_07_14_233825_create_capa_postagem.php
+++ b/src/database/migrations/2025_07_14_233825_create_capa_postagem.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('capa_postagem', function (Blueprint $table) {
+            $table->id();
+            $table->string("imagem");
+            $table->foreignId('postagem_id')->constrained(
+                table: 'postagem'
+            )->onDelete("cascade");
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('capa_postagem');
+    }
+};

--- a/src/resources/views/postagem/create.blade.php
+++ b/src/resources/views/postagem/create.blade.php
@@ -39,12 +39,12 @@
             </div>
 
             <div class="form-group">
-                <label for="tipo_postagem" class="form-label">Exibir na tela inicial com destaque? (necessário cadastrar imagem)</label>
-                <input type="checkbox" name="menu_inicial" id="menu_inicial" {{ old('menu_inicial') ? 'checked' : '' }}>
+                <label for="main-image" class="form-label">Capa da Postagem (2700 x 660)</label>
+                <input type="file" name="main_image" id="main_image" class="form-control">
             </div>
 
             <div class="form-group">
-                <label for="imagens" class="form-label">Imagens (caso for exibir na tela inicial, a primeira imagem deve ter a dimensão: 2700 x 660):</label>
+                <label for="imagens" class="form-label">Imagens:</label>
                 <input type="file" name="imagens[]" id="imagens" class="form-control" multiple>
                 
             </div>

--- a/src/resources/views/postagem/display.blade.php
+++ b/src/resources/views/postagem/display.blade.php
@@ -3,14 +3,14 @@
 @section('content')
 
 @php
-$imagensPostagens = [];
+$capasPostagens = [];
 foreach ($postagens as $postagem) {
     if ($postagem->isPinned()) {
-        $firstImage = $postagem->imagens->first();
-        if ($firstImage && Storage::disk('public')->exists($firstImage->imagem)) {
-            $imagensPostagens[] = [
+        $capa = $postagem->capa;
+        if ($capa && Storage::disk('public')->exists($capa->imagem)) {
+            $capasPostagens[] = [
                 'postagem' => $postagem,
-                'imagem' => $firstImage,
+                'imagem' => $capa,
             ];
         }
     }
@@ -20,24 +20,24 @@ foreach ($postagens as $postagem) {
 <div id="demo" class="container carousel slide" data-bs-ride="carousel" data-bs-interval="6000">
     <div class="carousel-indicators" id="carousel-indicators">
         <button type="button" data-bs-target="#demo" data-bs-slide-to="0" class="active"></button>
-        @foreach ($imagensPostagens as $index => $item)
-        <button type="button" data-bs-target="#demo" data-bs-slide-to="{{ $index + 1}}"></button>
+        @foreach ($capasPostagens as $index => $item)
+            <button type="button" data-bs-target="#demo" data-bs-slide-to="{{ $index + 1 }}"></button>
         @endforeach
     </div>
 
     <div class="carousel-inner" id="carousel-inner">
         <div class="carousel-item active">
-            <a href="{{ route('tcc.display')}}">
+            <a href="{{ route('tcc.display') }}">
                 <img src="{{ asset('images/convite_tcc.png') }}" alt="Image 1" class="carousel-image w-100 max-height-carousel">
             </a>
         </div>
 
-        @foreach ($imagensPostagens as $index => $item)
-        <div class="carousel-item">
-            <a href="{{ route('postagem.show', ['id' => $item['postagem']->id]) }}">
-                <img src="{{ URL::asset('storage') }}/{{ $item['imagem']->imagem }}" alt="Image {{ $index + 1 }}" class="carousel-image w-100 max-height-carousel">
-            </a>
-        </div>
+        @foreach ($capasPostagens as $index => $item)
+            <div class="carousel-item">
+                <a href="{{ route('postagem.show', ['id' => $item['postagem']->id]) }}">
+                    <img src="{{ URL::asset('storage') }}/{{ $item['imagem']->imagem }}" alt="Image {{ $index + 1 }}" class="carousel-image w-100 max-height-carousel">
+                </a>
+            </div>
         @endforeach
     </div>
 
@@ -59,36 +59,36 @@ foreach ($postagens as $postagem) {
     <div class="container">
         <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
             @foreach($postagens_9 as $postagem)
-            <div class="col">
-                <div class="card shadow-sm h-100">
-                    @if (count($postagem->imagens) > 0)
-                    @php $firstImage = $postagem->imagens[0]; @endphp
-                    @if (Storage::disk('public')->exists($firstImage->imagem) && $postagem->menu_inicial )
-                    <a href="{{ route('postagem.show', ['id' => $postagem->id]) }}">
-                        <img src="{{ URL::asset('storage') }}/{{ $firstImage->imagem }}" alt="{{ $postagem->titulo }}" class="bd-placeholder-img card-img-top" width="100%">
-                    </a>
-                    @else
-                    <a href="{{ route('postagem.show', ['id' => $postagem->id]) }}">
-                        <img src="{{ asset('images/postagem.png') }}" alt="{{ $postagem->titulo }}" class="bd-placeholder-img card-img-top" width="100%">
-                    </a>
-                    @endif
-                    @else
-                    <a href="{{ route('postagem.show', ['id' => $postagem->id]) }}">
-                        <img src="{{ asset('images/postagem.png') }}" alt="{{ $postagem->titulo }}" class="bd-placeholder-img card-img-top" width="100%">
-                    </a>
-                    @endif
+                <div class="col">
+                    <div class="card shadow-sm h-100">
+                        @if ($postagem->menu_inicial)
+                            @php $capa = $postagem->capa; @endphp
+                            @if (Storage::disk('public')->exists($capa->imagem) && $postagem->menu_inicial)
+                                <a href="{{ route('postagem.show', ['id' => $postagem->id]) }}">
+                                    <img src="{{ URL::asset('storage') }}/{{ $capa->imagem }}" alt="{{ $postagem->titulo }}" class="bd-placeholder-img card-img-top" width="100%">
+                                </a>
+                            @else
+                                <a href="{{ route('postagem.show', ['id' => $postagem->id]) }}">
+                                    <img src="{{ asset('images/postagem.png') }}" alt="{{ $postagem->titulo }}" class="bd-placeholder-img card-img-top" width="100%">
+                                </a>
+                            @endif
+                        @else
+                            <a href="{{ route('postagem.show', ['id' => $postagem->id]) }}">
+                                <img src="{{ asset('images/postagem.png') }}" alt="{{ $postagem->titulo }}" class="bd-placeholder-img card-img-top" width="100%">
+                            </a>
+                        @endif
 
-                    <div class="card-body d-flex flex-column">
-                        <p class="card-text flex-grow-1">{{ $postagem->titulo }}</p>
-                        <div class="d-flex justify-content-between align-items-end">
-                            <div class="btn-group">
-                                <a href="{{ route('postagem.show', ['id' => $postagem->id]) }}" class="btn btn-sm btn-outline-secondary">Visualizar</a>
+                        <div class="card-body d-flex flex-column">
+                            <p class="card-text flex-grow-1">{{ $postagem->titulo }}</p>
+                            <div class="d-flex justify-content-between align-items-end">
+                                <div class="btn-group">
+                                    <a href="{{ route('postagem.show', ['id' => $postagem->id]) }}" class="btn btn-sm btn-outline-secondary">Visualizar</a>
+                                </div>
+                                <small class="text-body-secondary">{{ $postagem->created_at->format('d/m/Y H:i') }}</small>
                             </div>
-                            <small class="text-body-secondary">{{ $postagem->created_at->format('d/m/Y H:i') }}</small>
                         </div>
                     </div>
                 </div>
-            </div>
             @endforeach
         </div>
     </div>
@@ -97,9 +97,9 @@ foreach ($postagens as $postagem) {
 @php
 $paginatorText = $postagens_9->onEachSide(1)->links('pagination::bootstrap-5')->toHtml();
 $translatedPaginatorText = str_replace(
-['Showing', 'to', 'of', 'results'],
-['Mostrando de', 'a', 'de', 'resultados'],
-$paginatorText
+    ['Showing', 'to', 'of', 'results'],
+    ['Mostrando de', 'a', 'de', 'resultados'],
+    $paginatorText
 );
 @endphp
 

--- a/src/resources/views/postagem/edit.blade.php
+++ b/src/resources/views/postagem/edit.blade.php
@@ -58,17 +58,24 @@
             </div>
 
             <div class="form-group">
-                <label for="tipo_postagem" class="form-label">Exibir na tela inicial com destaque? (necessário cadastrar imagem)</label>
-                <input type="checkbox" name="menu_inicial" id="menu_inicial" {{ $postagem->menu_inicial ? 'checked' : '' }}>
+                <label for="main-image" class="form-label">Capa da Postagem (2700 x 660)</label>
+                @if($postagem->menu_inicial)
+                    <img src="{{ asset('storage/'.$postagem->capa->imagem) }}" class="img-responsive"
+                        style="max-height:100px; max-width:100px;">
+                @endif
+                <input type="file" name="main_image" id="main_image" class="form-control">
             </div>
 
             <div class="form-group">
-                <label for="imagem" class="form-label">Imagens (caso for exibir na tela inicial, a primeira imagem deve ter a dimensão: 2700 x 660):</label>
-                @if (count($postagem->imagens) > 0)
-                    @foreach ($postagem->imagens as $img)
-                        <button class="btn text-danger" type="submit" form="deletar-imagens{{ $img->id }}">X</button>
-                        <img src="{{ URL::asset('storage') }}/{{ $img->imagem }}" class="img-responsive"
-                            style="max-height:100px; max-width:100px;">
+                <label for="imagens" class="form-label">Imagens:</label>
+                @if(count($postagem->imagens) > 0)
+                    @foreach($postagem->imagens as $img)
+                        <div class="mb-2">
+                            <button class="btn text-danger btn-sm" type="submit" form="deletar-imagens{{ $img->id }}">X</button>
+                            <img src="{{ asset('storage/'.$img->imagem) }}" 
+                                class="img-fluid" 
+                                style="max-height:100px; max-width:100px;">
+                        </div>
                     @endforeach
                 @endif
                 <input type="file" name="imagens[]" id="imagens" class="form-control" multiple>

--- a/src/resources/views/postagem/show.blade.php
+++ b/src/resources/views/postagem/show.blade.php
@@ -12,11 +12,11 @@
                     <div class="badge bg-secondary text-decoration-none link-light text-wrap">{{ $tipo_postagem->nome }}</div>
                 </header>
 
-                @if (count($postagem->imagens) > 0 && $postagem->menu_inicial)
+                @if ($postagem->menu_inicial)
                 <figure class="mb-4">
-                    @php $firstImage = $postagem->imagens[0]; @endphp
-                    @if (Storage::disk('public')->exists($firstImage->imagem))
-                    <img class="img-fluid rounded" src="{{ URL::asset('storage') }}/{{ $firstImage->imagem }}" alt="{{ $postagem->titulo }}">
+                    @php $capa = $postagem->capa; @endphp
+                    @if (Storage::disk('public')->exists($capa->imagem))
+                    <img class="img-fluid rounded" src="{{ URL::asset('storage') }}/{{ $capa->imagem }}" alt="{{ $postagem->titulo }}">
                     @endif
                 </figure>
                 @endif


### PR DESCRIPTION
## Classification

- [ ] New feature
- [ ] Fixing bugs
- [x] Improving the project
- [ ] Other (which one?)

## Description

This PR refactors the image handling logic in the post management system. The changes introduce a clear separation between the logic for handling the cover image (the main image) and additional attached images.

## What has been done

- Refactored image logic:
  -  The logic for processing the cover image has been separated from the handling of other images in the post.
  - A dedicated section for managing the cover image was created, including validation for the required dimensions.
  - Post images are now handled independently from the cover image.
- Improved method names:
  - Renamed and reorganized certain methods to reflect their specific responsibilities.
