### PR TITLE
Fix boostrap classes

### DIFF
--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -501,3 +501,14 @@ margin-top:60px;
   background-color: #c82333 !important;
   border-color: #bd2130 !important;
 }
+
+
+.note-image-dialog .note-group-image-upload {
+    display: none !important;
+}
+
+/* Regra para esconder completamente a seção de upload de imagens no modal do Summernote */
+.note-group-select-from-files {
+    display: none !important;
+}
+

--- a/src/resources/css/app.css
+++ b/src/resources/css/app.css
@@ -7,17 +7,4 @@
     color: black !important;
 }
 
-.note-image-dialog .note-group-image-upload {
-    display: none !important;
-}
 
-/* Regra para esconder completamente a seção de upload de imagens no modal do Summernote */
-.note-group-select-from-files {
-    display: none !important;
-}
-
-/* Suas outras regras de estilo, como .input-field */
-.input-field {
-    background-color: white !important;
-    color: black !important;
-}

--- a/src/resources/views/layouts/main.blade.php
+++ b/src/resources/views/layouts/main.blade.php
@@ -60,6 +60,7 @@
         }
     </style>
 
+    @vite(['resources/js/app.js'])
 
 </head>
 
@@ -109,7 +110,6 @@
         </div>
     </footer>
 
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
 </body>
 
 </html>


### PR DESCRIPTION
This commit fix the boostrap classes that were broken that the reinvetedposts PR broke.

<img width="1363" height="679" alt="image" src="https://github.com/user-attachments/assets/06fea5de-d0a1-4a38-93ab-3b43d5576d2e" />

<img width="1364" height="645" alt="image" src="https://github.com/user-attachments/assets/e641af8f-8027-48f0-b1ab-014a536d22bd" />

<img width="1366" height="469" alt="image" src="https://github.com/user-attachments/assets/d7c28c6e-ddc2-49fc-911e-e376a66da2cd" />

